### PR TITLE
Migrate from "github.com/kr/pty" to "github.com/creack/pty"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ See `gexpect_test.go` and the `examples` folder for full syntax
 
 ## Credits
 
-	github.com/kballard/go-shellquote	
-	github.com/kr/pty
+	github.com/creack/pty
+	github.com/kballard/go-shellquote
 	KMP Algorithm: "http://blog.databigbang.com/searching-for-substrings-in-streams-a-slight-modification-of-the-knuth-morris-pratt-algorithm-in-haxe/"

--- a/gexpect.go
+++ b/gexpect.go
@@ -13,8 +13,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/creack/pty"
 	shell "github.com/kballard/go-shellquote"
-	"github.com/kr/pty"
 )
 
 var (
@@ -387,7 +387,7 @@ func (expect *ExpectSubprocess) ReadUntil(delim byte) ([]byte, error) {
 		for i := 0; i < n; i++ {
 			if chunk[i] == delim {
 				if len(chunk) > i+1 {
-					expect.buf.PutBack(chunk[i+1:n])
+					expect.buf.PutBack(chunk[i+1 : n])
 				}
 				return join, nil
 			} else {


### PR DESCRIPTION
Fixes "Setctty set but Ctty not valid in child with Go" error
with Go 1.15 and up.  See https://github.com/creack/pty/issues/96